### PR TITLE
Ballot test passes

### DIFF
--- a/ballot/app/test/service.spec.ts
+++ b/ballot/app/test/service.spec.ts
@@ -6,8 +6,9 @@ describe('Ballot', () => {
   let service;
 
   beforeAll(async () => {
-    service = await oasis.workspace.Ballot.deploy({
-      header: {confidential: false},
+    service = await oasis.workspace.Ballot.deploy('Secret Ballot', ['Alice', 'Bob'], {
+      header: { confidential: false },
+      options: { gasLimit: '0xe79732' },
     });
   });
 


### PR DESCRIPTION
No constructor arguments were given upon deploy, even though the Ballot takes two: https://github.com/oasislabs/tutorials/blob/master/ballot/service/src/main.rs#L21