### PR TITLE
Pin correct versions to fix #63.

### DIFF
--- a/ballot/service/Cargo.lock
+++ b/ballot/service/Cargo.lock
@@ -9,11 +9,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "backtrace"
 version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,10 +48,10 @@ dependencies = [
 
 [[package]]
 name = "blockchain-traits"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "oasis-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -142,11 +137,11 @@ dependencies = [
 
 [[package]]
 name = "memchain"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "oasis-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -171,7 +166,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -188,8 +183,8 @@ name = "oasis-test"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchain 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "oasis-macros 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -202,17 +197,6 @@ dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "oasis-types"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -349,24 +333,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,11 +365,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
-"checksum anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bd490bed73bd6fef0f67199dc9f2847618ec7b3decf62b6ce6137ff974b9338c"
+"checksum blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eae7ec4d0280003585c6418bb05a4552eaead692832f58067f3d05b09c4cef1b"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
@@ -416,13 +381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum map_vec 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43e9839b06bd5129fa636a93cb53601ffae739b8ff115841374d110cafb02cad"
-"checksum memchain 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25e8d0097ce4e57c267b1f39960c107a7b54d3de2a224c5b272189b252ceb46f"
+"checksum memchain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "43f2685473e848a08bb277b9d8afb0d7f47400763b428f2f267de6f41d49f417"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum oasis-macros 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "216d8626ba4ac3aeff960eebc777e54091ceba844f28111d81dd6d7b2f08889a"
 "checksum oasis-std 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "af3d61e7481b7a4b53e77b6c156da3b4f8f39a469769f628ca554bba5cea291f"
 "checksum oasis-test 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "559bd9c8e14989d51228fd58b98d5e610d0257c3662dc8421cec761128e6ad7c"
 "checksum oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "751b6eebe5f32bb7fbd26224bdfc071c9a06047fe1469fe85503c11e12002555"
-"checksum oasis-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "43d0a0d8bfdaf98cfbe0539fd3e8df5868cccac8180c61c7d2ffb05d20d0054c"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
@@ -439,8 +403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
-"checksum thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6f357d1814b33bc2dc221243f8424104bfe72dbe911d5b71b3816a2dff1c977e"
-"checksum thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/dice-game/service/Cargo.lock
+++ b/dice-game/service/Cargo.lock
@@ -9,11 +9,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "backtrace"
 version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,10 +38,10 @@ dependencies = [
 
 [[package]]
 name = "blockchain-traits"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "oasis-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -150,11 +145,11 @@ dependencies = [
 
 [[package]]
 name = "memchain"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "oasis-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -190,7 +185,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -207,8 +202,8 @@ name = "oasis-test"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchain 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "oasis-macros 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -221,17 +216,6 @@ dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "oasis-types"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -410,24 +394,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,11 +426,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
-"checksum anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bd490bed73bd6fef0f67199dc9f2847618ec7b3decf62b6ce6137ff974b9338c"
+"checksum blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eae7ec4d0280003585c6418bb05a4552eaead692832f58067f3d05b09c4cef1b"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
@@ -479,13 +444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum map_vec 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43e9839b06bd5129fa636a93cb53601ffae739b8ff115841374d110cafb02cad"
-"checksum memchain 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25e8d0097ce4e57c267b1f39960c107a7b54d3de2a224c5b272189b252ceb46f"
+"checksum memchain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "43f2685473e848a08bb277b9d8afb0d7f47400763b428f2f267de6f41d49f417"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum oasis-macros 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "216d8626ba4ac3aeff960eebc777e54091ceba844f28111d81dd6d7b2f08889a"
 "checksum oasis-std 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "af3d61e7481b7a4b53e77b6c156da3b4f8f39a469769f628ca554bba5cea291f"
 "checksum oasis-test 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "559bd9c8e14989d51228fd58b98d5e610d0257c3662dc8421cec761128e6ad7c"
 "checksum oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "751b6eebe5f32bb7fbd26224bdfc071c9a06047fe1469fe85503c11e12002555"
-"checksum oasis-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "43d0a0d8bfdaf98cfbe0539fd3e8df5868cccac8180c61c7d2ffb05d20d0054c"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
@@ -507,8 +471,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
-"checksum thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6f357d1814b33bc2dc221243f8424104bfe72dbe911d5b71b3816a2dff1c977e"
-"checksum thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/hello-world/service/Cargo.lock
+++ b/hello-world/service/Cargo.lock
@@ -9,11 +9,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "backtrace"
 version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,10 +38,10 @@ dependencies = [
 
 [[package]]
 name = "blockchain-traits"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "oasis-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -142,11 +137,11 @@ dependencies = [
 
 [[package]]
 name = "memchain"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "oasis-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -171,7 +166,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -188,8 +183,8 @@ name = "oasis-test"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchain 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "oasis-macros 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -202,17 +197,6 @@ dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "oasis-types"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -349,24 +333,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,11 +365,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
-"checksum anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bd490bed73bd6fef0f67199dc9f2847618ec7b3decf62b6ce6137ff974b9338c"
+"checksum blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eae7ec4d0280003585c6418bb05a4552eaead692832f58067f3d05b09c4cef1b"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
@@ -416,13 +381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum map_vec 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43e9839b06bd5129fa636a93cb53601ffae739b8ff115841374d110cafb02cad"
-"checksum memchain 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25e8d0097ce4e57c267b1f39960c107a7b54d3de2a224c5b272189b252ceb46f"
+"checksum memchain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "43f2685473e848a08bb277b9d8afb0d7f47400763b428f2f267de6f41d49f417"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum oasis-macros 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "216d8626ba4ac3aeff960eebc777e54091ceba844f28111d81dd6d7b2f08889a"
 "checksum oasis-std 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "af3d61e7481b7a4b53e77b6c156da3b4f8f39a469769f628ca554bba5cea291f"
 "checksum oasis-test 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "559bd9c8e14989d51228fd58b98d5e610d0257c3662dc8421cec761128e6ad7c"
 "checksum oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "751b6eebe5f32bb7fbd26224bdfc071c9a06047fe1469fe85503c11e12002555"
-"checksum oasis-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "43d0a0d8bfdaf98cfbe0539fd3e8df5868cccac8180c61c7d2ffb05d20d0054c"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
@@ -439,8 +403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
-"checksum thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6f357d1814b33bc2dc221243f8424104bfe72dbe911d5b71b3816a2dff1c977e"
-"checksum thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/rock-paper-scissors/service/Cargo.lock
+++ b/rock-paper-scissors/service/Cargo.lock
@@ -9,11 +9,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "backtrace"
 version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,10 +38,10 @@ dependencies = [
 
 [[package]]
 name = "blockchain-traits"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "oasis-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -124,11 +119,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchain"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "oasis-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -153,7 +148,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -170,8 +165,8 @@ name = "oasis-test"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchain 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "oasis-macros 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -184,17 +179,6 @@ dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "oasis-types"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -340,24 +324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,11 +356,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
-"checksum anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum blockchain-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bd490bed73bd6fef0f67199dc9f2847618ec7b3decf62b6ce6137ff974b9338c"
+"checksum blockchain-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eae7ec4d0280003585c6418bb05a4552eaead692832f58067f3d05b09c4cef1b"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
@@ -406,13 +371,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
-"checksum memchain 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25e8d0097ce4e57c267b1f39960c107a7b54d3de2a224c5b272189b252ceb46f"
+"checksum memchain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "43f2685473e848a08bb277b9d8afb0d7f47400763b428f2f267de6f41d49f417"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum oasis-macros 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "216d8626ba4ac3aeff960eebc777e54091ceba844f28111d81dd6d7b2f08889a"
 "checksum oasis-std 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "af3d61e7481b7a4b53e77b6c156da3b4f8f39a469769f628ca554bba5cea291f"
 "checksum oasis-test 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "559bd9c8e14989d51228fd58b98d5e610d0257c3662dc8421cec761128e6ad7c"
 "checksum oasis-types 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "751b6eebe5f32bb7fbd26224bdfc071c9a06047fe1469fe85503c11e12002555"
-"checksum oasis-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "43d0a0d8bfdaf98cfbe0539fd3e8df5868cccac8180c61c7d2ffb05d20d0054c"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
@@ -429,8 +393,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
-"checksum thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6f357d1814b33bc2dc221243f8424104bfe72dbe911d5b71b3816a2dff1c977e"
-"checksum thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"


### PR DESCRIPTION
Fixes issue #63 by downgrading to `blockchain-traits=0.2.2` and `memchain=0.2.3`.

All `Cargo.lock` files were updated using these commands:

```
$ cargo update -p oasis-types --precise 0.2.2
error: There are multiple `oasis-types` packages in your project, and the specification `oasis-types` is ambiguous.
Please re-run this command with `-p <spec>` where `<spec>` is one of the following:
  oasis-types:0.2.2
  oasis-types:0.3.1

$ cargo update -p oasis-types:0.3.1 --precise 0.2.2
    Updating crates.io index
error: failed to select a version for the requirement `oasis-types = "^0.3"`
  candidate versions found which didn't match: 0.2.2
  location searched: crates.io index
required by package `blockchain-traits v0.2.3`
    ... which is depended on by `oasis-std v0.2.7`
    ... which is depended on by `hello-world v0.1.0 (/srv/tutorials/hello-world/service)`

$ cargo update -p blockchain-traits --precise 0.2.2
    Updating crates.io index
    Updating blockchain-traits v0.2.3 -> v0.2.2

$ cargo update -p memchain --precise 0.2.3
    Updating crates.io index
    Removing anyhow v1.0.25
    Updating memchain v0.2.4 -> v0.2.3
    Removing oasis-types v0.3.1
    Removing thiserror v1.0.9
    Removing thiserror-impl v1.0.9
```